### PR TITLE
Draft: add gi-docgen to the build system

### DIFF
--- a/doc/lsp-glib.toml.in
+++ b/doc/lsp-glib.toml.in
@@ -1,0 +1,34 @@
+[library]
+version = @VERSION@
+browse_url = "https://github.com/prince781/lsp-glib"
+repository_url = "https://github.com/prince781/lsp-glib.git"
+website_url = "https://github.com/prince781/lsp-glib.git"
+authors = "Princeton Ferro"
+license = "LGPL-2.1"
+description = "LSP library built on GLib. Designed for both editors and servers."
+dependencies = ["GObject-2.0", "Jsonrpc-1.0", "Gee-0.8"]
+devhelp = true
+search_index = true
+
+  [dependencies."GObject-2.0"]
+  name = "GObject"
+  description = "The base type system library"
+  docs_url = "https://docs.gtk.org/gobject/"
+
+  [dependencies."Jsonrpc-1.0"]
+  name = "jsonrpc-glib"
+  description = "jsonrpc-glib is a library to communicate using the JSON-RPC 2.0 specification."
+  docs_url = "https://gnome.pages.gitlab.gnome.org/jsonrpc-glib/"
+
+  [dependencies."Gee-0.8"]
+  name = "libgee"
+  description = "Libgee is a collection library providing GObject-based interfaces and classes for commonly used data structures."
+
+[theme]
+name = "basic"
+show_index_summary = true
+show_class_hierarchy = true
+
+[source-location]
+base_url = "https://github.com/prince781/lsp-glib/tree/master/"
+

--- a/doc/lsp-glib.toml.in
+++ b/doc/lsp-glib.toml.in
@@ -2,13 +2,13 @@
 version = @VERSION@
 browse_url = "https://github.com/prince781/lsp-glib"
 repository_url = "https://github.com/prince781/lsp-glib.git"
-website_url = "https://github.com/prince781/lsp-glib.git"
+website_url = "https://github.com/prince781/lsp-glib"
 authors = "Princeton Ferro"
 license = "LGPL-2.1"
 description = "LSP library built on GLib. Designed for both editors and servers."
-dependencies = ["GObject-2.0", "Jsonrpc-1.0", "Gee-0.8"]
-devhelp = true
-search_index = true
+dependencies = ["GObject-2.0", "Jsonrpc-1.0", "Gio-2.0"]
+devhelp = false
+search_index = false
 
   [dependencies."GObject-2.0"]
   name = "GObject"
@@ -16,13 +16,13 @@ search_index = true
   docs_url = "https://docs.gtk.org/gobject/"
 
   [dependencies."Jsonrpc-1.0"]
-  name = "jsonrpc-glib"
-  description = "jsonrpc-glib is a library to communicate using the JSON-RPC 2.0 specification."
+  name = "Jsonrpc-glib"
+  description = "Library to communicate using the JSON-RPC 2.0 specification."
   docs_url = "https://gnome.pages.gitlab.gnome.org/jsonrpc-glib/"
 
-  [dependencies."Gee-0.8"]
-  name = "libgee"
-  description = "Libgee is a collection library providing GObject-based interfaces and classes for commonly used data structures."
+  [dependencies."Gio-2.0"]
+  name = "Gio"
+  description = "GObject Interfaces and Objects, Networking, IPC, and I/O"
 
 [theme]
 name = "basic"

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,63 @@
+if get_option('enable_valadoc')
+  valadoc = find_program('valadoc')
+  lsp_glib_docs = custom_target('lsp-glib_apidocs',
+    input: sources,
+    install: true,
+    # FIXME: Installing to tmp, so the target will be built
+    #        the problem is we cannot access a subfolder of the
+    #        buildtarget via the output parameter.
+    #        Find a nicer solution
+    install_dir: get_option('datadir') / 'devhelp' / 'books',
+    command: [
+      valadoc,
+      '-o', 'valadoc',
+      '--doclet',
+      'devhelp',
+      '@INPUT@',
+      '--pkg', 'glib-2.0',
+      '--pkg', 'gobject-2.0',
+      '--pkg', 'gio-2.0',
+      '--pkg', 'jsonrpc-glib-1.0',
+      '--force',
+      '--use-svg-images',
+      '--package-name', 'lsp-glib-' + API_VERSION,
+      '--package-version', API_VERSION
+    ],
+    output: 'Lsp-' + API_VERSION)
+
+  install_subdir(meson.current_build_dir() / 'Lsp-' + API_VERSION / 'lsp-glib-' + API_VERSION,
+    install_dir: get_option('datadir') / 'devhelp' / 'books')
+endif
+
+if get_option('gi-docgen')
+  gidocgen_dep = dependency('gi-docgen', version: '>= 2021.6',
+                            fallback: ['gi-docgen', 'dummy_dep'],
+                            required: true)
+
+  gidocgen = find_program('gi-docgen', required: true)
+
+  toml_conf = configuration_data()
+  toml_conf.set('VERSION', API_VERSION)
+
+  lsp_glib_toml = configure_file(input: 'lsp-glib.toml.in',
+                                 output: 'lsp-glib.toml',
+                                 configuration: toml_conf)
+
+  custom_target('gi-docgen',
+    input: [lsp_glib_toml],
+    output: 'gi-docgen',
+    command: [
+      gidocgen,
+      'generate',
+      #'--quiet',
+      '--no-namespace-dir',
+      '--fatal-warnings',
+      '--config=@INPUT0@',
+      '--output-dir=@OUTPUT@',
+      '--content-dir=@0@'.format(meson.current_source_dir()),
+      lsp_glib_gir,
+    ],
+    build_by_default: true,
+    depends: liblsp_glib,
+  )
+endif

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,6 +1,6 @@
 if get_option('enable_valadoc')
   valadoc = find_program('valadoc')
-  lsp_glib_docs = custom_target('lsp-glib_apidocs',
+  lsp_glib_docs = custom_target('valadoc-api-docs',
     input: sources,
     install: true,
     # FIXME: Installing to tmp, so the target will be built
@@ -10,7 +10,7 @@ if get_option('enable_valadoc')
     install_dir: get_option('datadir') / 'devhelp' / 'books',
     command: [
       valadoc,
-      '-o', 'valadoc',
+      '-o', meson.current_build_dir() / 'valadoc',
       '--doclet',
       'devhelp',
       '@INPUT@',
@@ -43,7 +43,7 @@ if get_option('gi-docgen')
                                  output: 'lsp-glib.toml',
                                  configuration: toml_conf)
 
-  custom_target('gi-docgen',
+  custom_target('gi-docgen-api-docs',
     input: [lsp_glib_toml],
     output: 'gi-docgen',
     command: [

--- a/meson.build
+++ b/meson.build
@@ -24,3 +24,4 @@ version_file = vcs_tag(input: 'version.vala.in',
                        command: ['git', 'describe', '--tags', '--dirty'])
 
 subdir('src')
+subdir('doc')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,2 @@
 option('enable_valadoc', type: 'boolean', value: true)
-
+option('gi-docgen', type: 'boolean', value: true) 

--- a/src/meson.build
+++ b/src/meson.build
@@ -45,6 +45,8 @@ liblsp_glib = library('lsp-glib-' + API_VERSION,
   ]
 )
 
+lsp_glib_gir = meson.current_build_dir() / 'Lsp-' + API_VERSION + '.gir'
+
 install_data('lsp-glib.deps',
              install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'vala', 'vapi'))
 
@@ -76,33 +78,3 @@ lsp_glib_dep = declare_dependency(
   include_directories: [include_directories('.')]
 )
 
-if get_option('enable_valadoc')
-  valadoc = find_program('valadoc')
-  lsp_glib_docs = custom_target('lsp-glib_apidocs',
-    input: sources,
-    install: true,
-    # FIXME: Installing to tmp, so the target will be built
-    #        the problem is we cannot access a subfolder of the
-    #        buildtarget via the output parameter.
-    #        Find a nicer solution
-    install_dir: get_option('datadir') / 'devhelp' / 'books',
-    command: [
-      valadoc,
-      '-o', meson.current_build_dir() / 'Lsp-' + API_VERSION,
-      '--doclet',
-      'devhelp',
-      '@INPUT@',
-      '--pkg', 'glib-2.0',
-      '--pkg', 'gobject-2.0',
-      '--pkg', 'gio-2.0',
-      '--pkg', 'jsonrpc-glib-1.0',
-      '--force',
-      '--use-svg-images',
-      '--package-name', 'lsp-glib-' + API_VERSION,
-      '--package-version', API_VERSION
-    ],
-    output: 'Lsp-' + API_VERSION)
-
-  install_subdir(meson.current_build_dir() / 'Lsp-' + API_VERSION / 'lsp-glib-' + API_VERSION,
-    install_dir: get_option('datadir') / 'devhelp' / 'books')
-endif

--- a/subprojects/gi-docgen.wrap
+++ b/subprojects/gi-docgen.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+directory=gi-docgen
+url=https://gitlab.gnome.org/GNOME/gi-docgen.git
+push-url=ssh://git@gitlab.gnome.org:GNOME/gi-docgen.git
+revision=main
+depth=1
+


### PR DESCRIPTION
There are some parts not yet fully finiished.

Especially ``gi-docgen`` fails with an exception during build.

The docs are generated though, so you can browse them under ``$builddir/docs/gi-docgen/index.html``

I also moved the valadoc docs into the `docs` folder, to organize them better.