### PR TITLE
Make compact classes opaque

### DIFF
--- a/src/types/clientcapabilities.vala
+++ b/src/types/clientcapabilities.vala
@@ -86,6 +86,7 @@ namespace Lsp {
      * 
      * @see WorkspaceEditClientCaps.resource_ops
      */
+    [Compact (opaque = true)]
     public class WorkspaceEditClientCaps {
         /**
          * The client supports versioned document changes in {@link WorkspaceEdit}s
@@ -140,7 +141,23 @@ namespace Lsp {
     /**
      * Workspace-specific client capabilities.
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_workspace_client_caps_ref", unref_function = "lsp_workspace_client_caps_unref")]
     public class WorkspaceClientCaps {
+        private int ref_count = 1;
+
+        public unowned WorkspaceClientCaps ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * The client supports applying batch edits to the workspace by
          * supporting the request 'workspace/applyEdit'
@@ -151,7 +168,23 @@ namespace Lsp {
     /**
      * Completion-specific client capabilities
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_completion_client_caps_ref", unref_function = "lsp_completion_client_caps_unref")]
     public class CompletionClientCaps {
+        private int ref_count = 1;
+
+        public unowned CompletionClientCaps ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * Client supports snippets as insert text.
 		 *
@@ -264,7 +297,23 @@ namespace Lsp {
     /**
      * Text document-specific client capabilities.
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_text_document_client_caps_ref", unref_function = "lsp_text_document_client_caps_unref")]
     public class TextDocumentClientCaps {
+        private int ref_count = 1;
+
+        public unowned TextDocumentClientCaps ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         public TextDocumentSyncClientCaps synchronization { get; set; }
 
         public CompletionClientCaps completion { get; set; }
@@ -273,7 +322,23 @@ namespace Lsp {
     /**
      * Capabilities of the client / editor.
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_client_caps_ref", unref_function = "lsp_client_caps_unref")]
     public class ClientCaps {
+        private int ref_count = 1;
+
+        public unowned ClientCaps ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * Workspace-specific client capabilities.
          */

--- a/src/types/command.vala
+++ b/src/types/command.vala
@@ -29,10 +29,10 @@ namespace Lsp {
      * Alternatively the tool extension code could handle the command. The
      * protocol currently doesn’t specify a set of well-known commands.
      */
-    [Compact]
+    [Compact (opaque=true)]
     [CCode (ref_function = "lsp_command_ref", unref_function = "lsp_command_unref")]
     public class Command {
-        public int ref_count = 1;
+        private int ref_count = 1;
 
         public unowned Command ref () {
             AtomicInt.add (ref this.ref_count, 1);
@@ -49,17 +49,17 @@ namespace Lsp {
         /**
          * Title of the command, like `save`.
          */
-        public string title;
+        public string title { get; set; }
 
         /**
          * The identifier of the actual command handler.
          */
-        public string command;
+        public string command { get; set; }
 
         /**
          * Arguments that the command handler should be invoked with.
          */
-        public Variant[]? arguments;
+        public Variant[]? arguments { get; set; }
 
         public Command (string title, string command, Variant[]? arguments = null) {
             this.title = title;

--- a/src/types/completion.vala
+++ b/src/types/completion.vala
@@ -106,7 +106,23 @@ namespace Lsp {
         DEPRECATED
     }
 
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_completion_item_ref", unref_function = "lsp_completion_item_unref")]
     public class CompletionItem {
+        private int ref_count = 1;
+
+        public unowned CompletionItem ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         public string label { get; set; }
 
         public CompletionItemKind kind { get; set; }

--- a/src/types/diagnostic.vala
+++ b/src/types/diagnostic.vala
@@ -24,12 +24,12 @@ namespace Lsp {
      *
      * @since 3.16.0
      */
-    [Compact]
+    [Compact (opaque=true)]
     public class CodeDescription {
         /**
          * An URI to open with more information about the diagnostic error.
          */
-        public string href;
+        public string href { get; set; }
 
         public CodeDescription (string href) {
             this.href = href;
@@ -113,10 +113,10 @@ namespace Lsp {
      * 
      * Diagnostic objects are only valid in the scope of a resource.
      */
-    [Compact]
+    [Compact (opaque=true)]
     [CCode (ref_function = "lsp_diagnostic_ref", unref_function = "lsp_diagnostic_unref")]
     public class Diagnostic {
-        public int ref_count = 1;
+        private int ref_count = 1;
 
         public unowned Diagnostic ref () {
             AtomicInt.add (ref this.ref_count, 1);
@@ -133,50 +133,50 @@ namespace Lsp {
         /**
          * The range at which the message applies.
          */
-        public Range range;
+        public Range range { get; set; }
 
         /**
          * The diagnostic's severity. Can be omitted. If omitted it is up to
          * the client to interpret diagnostics as error, warning, info or hint.
          */
-        public DiagnosticSeverity severity;
+        public DiagnosticSeverity severity { get; set; }
 
         /**
          * The diagnostic's code, which might appear in the user interface.
          */
-        public string? code;
+        public string? code { get; set; }
 
         /**
          * An optional property to describe the error code.
          *
          * @since 3.16.0
          */
-        public CodeDescription? code_description;
+        public CodeDescription? code_description { get; owned set; }
 
         /**
          * A human-readable string describing the source of this diagnostic,
          * e.g. 'vala' or 'vala lint'.
          */
-        public string? source;
+        public string? source { get; set; }
 
         /**
          * The diagnostic's message.
          */
-        public string message;
+        public string message { get; set; }
 
         /**
          * Additional metadata about the diagnostic.
          *
          * @since 3.15.0
          */
-        public DiagnosticTag[]? tags;
+        public DiagnosticTag[]? tags { get; set; }
 
         /**
          * An array of related diagnostic information, e.g. when symbol-names
          * within a scope collide all definitions can be marked via this
          * property.
          */
-        public DiagnosticRelatedInformation[]? related_information;
+        public DiagnosticRelatedInformation[]? related_information { get; set; }
           
         /**
          * A data entry field that is preserved between a
@@ -185,7 +185,7 @@ namespace Lsp {
          *
          * @since 3.16.0
          */
-        public Variant? data;
+        public Variant? data { get; set; }
 
         public Diagnostic (string message, Range range) {
             this.message = message;

--- a/src/types/initialization.vala
+++ b/src/types/initialization.vala
@@ -24,7 +24,23 @@ namespace Lsp {
      *
      * @since 3.15.0
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_client_info_ref", unref_function = "lsp_client_info_unref")]
     public class ClientInfo {
+        private int ref_count = 1;
+
+        public unowned ClientInfo ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         public string name { get; set; }
         public string? version { get; set; }
 
@@ -45,7 +61,23 @@ namespace Lsp {
     /**
      * Sent from the client / editor to the server.
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_initialize_params_ref", unref_function = "lsp_initialize_params_unref")]
     public class InitializeParams {
+        private int ref_count = 1;
+
+        public unowned InitializeParams ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         public int64 process_id { get; private set; }
 
         /**
@@ -146,7 +178,23 @@ namespace Lsp {
      *
      * @since 3.15.0
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_server_info_ref", unref_function = "lsp_server_info_unref")]
     public class ServerInfo {
+        private int ref_count = 1;
+
+        public unowned ServerInfo ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         public string name { get; set; }
         public string? version { get; set; }
 
@@ -170,7 +218,23 @@ namespace Lsp {
      * Sent from the language server to the client / editor after
      * initialization.
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_initialize_result_ref", unref_function = "lsp_initialize_result_unref")]
     public class InitializeResult {
+        private int ref_count = 1;
+
+        public unowned InitializeResult ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * The capabilities the language server provides.
          */

--- a/src/types/markupcontent.vala
+++ b/src/types/markupcontent.vala
@@ -55,10 +55,10 @@ namespace Lsp {
      * ''Please Note'' that clients might sanitize the return markdown. A client could
      * decide to remove HTML from the markdown to avoid script execution.
      */
-    [Compact]
+    [Compact (opaque=true)]
     [CCode (ref_function = "lsp_markup_content_ref", unref_function = "lsp_markup_content_unref")]
     public class MarkupContent {
-        public int ref_count = 1;
+        private int ref_count = 1;
 
         public unowned MarkupContent ref () {
             AtomicInt.add (ref this.ref_count, 1);
@@ -75,12 +75,12 @@ namespace Lsp {
         /**
          * The type of the markup
          */
-        public MarkupKind kind;
+        public MarkupKind kind { get; set; }
 
         /**
          * The content itself
          */
-        public string value;
+        public string value { get; set; }
 
         public MarkupContent (MarkupKind kind, string value) {
             this.kind = kind;

--- a/src/types/message.vala
+++ b/src/types/message.vala
@@ -45,7 +45,7 @@ namespace Lsp {
         /**
          * A short title like 'Retry', 'Open Log', etc.
          */
-        public string title;
+        public string title { get; set; }
 
         public MessageActionItem (string title) {
             this.title = title;

--- a/src/types/servercapabilities.vala
+++ b/src/types/servercapabilities.vala
@@ -19,7 +19,23 @@
  */
 
 namespace Lsp {
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_completion_options_ref", unref_function = "lsp_completion_options_unref")]
     public class CompletionOptions {
+        private int ref_count = 1;
+
+        public unowned CompletionOptions ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * Most tools trigger completion request automatically without
          * explicitly requesting it using a keyboard shortcut (e.g.
@@ -128,7 +144,23 @@ namespace Lsp {
         }
     }
 
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_code_lens_options_ref", unref_function = "lsp_code_lens_options_unref")]
     public class CodeLensOptions {
+        private int ref_count = 1;
+
+        public unowned CodeLensOptions ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * Code lens has a resolve provider as well.
          */
@@ -154,7 +186,23 @@ namespace Lsp {
         }
     }
 
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_document_link_options_ref", unref_function = "lsp_document_link_options_unref")]
     public class DocumentLinkOptions {
+        private int ref_count = 1;
+
+        public unowned DocumentLinkOptions ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * Document links have a resolve provider as well.
          */
@@ -180,7 +228,23 @@ namespace Lsp {
         }
     }
 
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_document_on_type_formatting_options_ref", unref_function = "lsp_document_on_type_formatting_options_unref")]
     public class DocumentOnTypeFormattingOptions {
+        private int ref_count = 1;
+
+        public unowned DocumentOnTypeFormattingOptions ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * The character on which formatting should be triggered, like `}`.
          */
@@ -216,7 +280,23 @@ namespace Lsp {
         }
     }
 
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_rename_options_ref", unref_function = "lsp_rename_options_unref")]
     public class RenameOptions {
+        private int ref_count = 1;
+
+        public unowned RenameOptions ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * The server supports renames being checked and tested before being
          * executed.
@@ -246,7 +326,23 @@ namespace Lsp {
     /**
      * The capabilities of the language server.
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_server_caps_ref", unref_function = "lsp_server_caps_unref")]
     public class ServerCaps {
+        private int ref_count = 1;
+
+        public unowned ServerCaps ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * Defines how text documents are synced.
          */

--- a/src/types/textdocument.vala
+++ b/src/types/textdocument.vala
@@ -271,7 +271,23 @@ namespace Lsp {
     /**
      * An item to transfer a text document from the client to the server.
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_text_document_item_ref", unref_function = "lsp_text_document_item_unref")]
     public class TextDocumentItem {
+        private int ref_count = 1;
+
+        public unowned TextDocumentItem ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * The text document's URI
          */

--- a/src/types/textedit.vala
+++ b/src/types/textedit.vala
@@ -22,8 +22,7 @@ namespace Lsp {
     /**
      * A textual edit applicable to a text document.
      */
-    [Compact (opaque=true)]
-    public class TextEdit {
+    public struct TextEdit {
         /**
          * The range of the text document to be manipulated. To insert text
          * into a document create a range where start === end.
@@ -71,8 +70,23 @@ namespace Lsp {
      *
      * @since 3.16.0
      */
-    [Compact (opaque=true)]
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_change_annotation_ref", unref_function = "Lsp_change_annotation_unref")]
     public class ChangeAnnotation {
+        private int ref_count = 1;
+
+        public unowned ChangeAnnotation ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * A human-readable string describing the actual change. The string is
          * rendered prominent in the user interface.
@@ -125,7 +139,7 @@ namespace Lsp {
          */
         public TextEdit[] edits {
             get { return _edits; }
-            owned set {
+            set {
                 for (var i = 0; i < value.length; i++)
                     _edits += (owned)value[i];
             }

--- a/src/types/textedit.vala
+++ b/src/types/textedit.vala
@@ -62,7 +62,7 @@ namespace Lsp {
         public TextEdit (Range range, string new_text, string? annotation_id = null) {
             this.range = range;
             this.new_text = new_text;
-            this.annotation_id = null;
+            this.annotation_id = annotation_id;
         }
     }
 

--- a/src/types/textedit.vala
+++ b/src/types/textedit.vala
@@ -22,19 +22,19 @@ namespace Lsp {
     /**
      * A textual edit applicable to a text document.
      */
-    [Compact]
+    [Compact (opaque=true)]
     public class TextEdit {
         /**
          * The range of the text document to be manipulated. To insert text
          * into a document create a range where start === end.
          */
-        public Range range;
+        public Range range { get; set; }
 
         /**
          * The string to be inserted. For delete operations use an empty
          * string.
          */
-        public string new_text;
+        public string new_text { get; set; }
 
         /**
          * An identifier referring to a change annotation managed by a workspace
@@ -57,7 +57,7 @@ namespace Lsp {
          *
          * @since 3.16.0
          */
-        public string? annotation_id;
+        public string? annotation_id { get; set; }
 
         public TextEdit (Range range, string new_text, string? annotation_id = null) {
             this.range = range;
@@ -71,25 +71,25 @@ namespace Lsp {
      *
      * @since 3.16.0
      */
-    [Compact]
+    [Compact (opaque=true)]
     public class ChangeAnnotation {
         /**
          * A human-readable string describing the actual change. The string is
          * rendered prominent in the user interface.
          */
-        public string label;
+        public string label { get; set; }
 
         /**
          * A flag which indicates that user confirmation is needed before
          * applying the change.
          */
-        public bool needs_confirmation;
+        public bool needs_confirmation { get; set; }
 
         /**
          * A human-readable string which is rendered less prominent in the user
          * interface.
          */
-        public string? description;
+        public string? description { get; set; }
 
         public ChangeAnnotation (string label, bool needs_confirmation = false, string? description = null) {
             this.label = label;

--- a/src/types/workspace.vala
+++ b/src/types/workspace.vala
@@ -19,7 +19,23 @@
  */
 
 namespace Lsp {
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_workspace_folder_ref", unref_function = "lsp_workspace_folder_unref")]
     public class WorkspaceFolder {
+        private int ref_count = 1;
+
+        public unowned WorkspaceFolder ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * The URI associated with the root of this workspace folder.
          */

--- a/src/types/workspaceedit.vala
+++ b/src/types/workspaceedit.vala
@@ -99,7 +99,23 @@ namespace Lsp {
      * A workspace edit represents changes to many resources managed in the
      * workspace.
      */
+    [Compact (opaque = true)]
+    [CCode (ref_function = "lsp_workspace_edit_ref", unref_function = "lsp_workspace_edit_unref")]
     public class WorkspaceEdit {
+        private int ref_count = 1;
+
+        public unowned WorkspaceEdit ref () {
+            AtomicInt.add (ref this.ref_count, 1);
+            return this;
+        }
+
+        public void unref () {
+            if (AtomicInt.dec_and_test (ref this.ref_count))
+                this.free ();
+        }
+
+        private extern void free ();
+
         /**
          * Holds changes to existing resources.
          *


### PR DESCRIPTION
This allows private fields, for example reference counter.

Maybe some other fields can be also made private.